### PR TITLE
Remove centering of h2 headers

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -23,11 +23,6 @@
   .team-member-photo {
     margin: auto auto 1em auto;
   }
-
-  h2 {
-    text-align: center;
-  }
-
 }
 
 @media (min-width: 38em) {

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -23,6 +23,10 @@
   .team-member-photo {
     margin: auto auto 1em auto;
   }
+
+  .team-member-name {
+    text-align: center;
+  }
 }
 
 @media (min-width: 38em) {

--- a/team.html
+++ b/team.html
@@ -16,11 +16,13 @@ title: Команда курса
     </div>
     
     <div class="team-member-right">
+      <h2 class="team-member-name">
       {% if member.site %}
-        <h2><a href="{{ member.site }}">{{ member.name }}</a></h2>
+        <a href="{{ member.site }}">{{ member.name }}</a>
       {% else %}
-        <h2>{{ member.name }}</h2>
+        {{ member.name }}
       {% endif %}
+      </h2>
 
       {% if member.description %}
         <div>{{ member.description }}</div>


### PR DESCRIPTION
У меня вопрос по поводу перемещения заголовков второго уровня в центр. Насколько я понимаю, это было сделано для страницы команды, но сейчас перемещаются h2 заголовки на всех страницах (h1 и h3 остаются на месте), что выглядит не очень красиво, на мой вкус. Это всё ещё нужно, и если да, то может стоит это сделать только для страницы `team`?